### PR TITLE
Fix parsing literals which contains a logical operator

### DIFF
--- a/lib/logical_query_parser.treetop
+++ b/lib/logical_query_parser.treetop
@@ -28,7 +28,7 @@ grammar LogicalQueryParser
   end
 
   rule unquoted_word
-    atom+
+    [^\s*()]+ !{ |word| %w[AND and && & OR or || | NOT not - - －].include? word[0].text_value }
   end
 
   rule lparen
@@ -69,9 +69,5 @@ grammar LogicalQueryParser
 
   rule sp
     ' ' / '　'
-  end
-
-  rule atom
-    !(lparen / rparen /and_ope / or_ope / not_ope / not_sym / sp) .
   end
 end

--- a/spec/active_record_helper.rb
+++ b/spec/active_record_helper.rb
@@ -38,6 +38,8 @@ def debug(str)
 end
 
 def sequence(strs)
-  strs.map! { |s| Regexp.escape(s) }
-  Regexp.new(strs.join('.*'))
+  strs.map! do |s|
+    Regexp.escape(s)
+  end
+  Regexp.new(strs.join('[^()]*'))
 end

--- a/spec/logical_query_parser/nodes/active_record_spec.rb
+++ b/spec/logical_query_parser/nodes/active_record_spec.rb
@@ -24,7 +24,7 @@ describe LogicalQueryParser do
     it 'parses quoted words' do
       result = parser.parse('"aa bb"').to_sql(options)
       debug(result)
-      expect(result).to match sequence %w|title aa bb OR body aa bb|
+      expect(result).to match sequence %w|title aa\ bb OR body aa\ bb|
       expect(Doc.where(result).to_a).not_to be_nil
     end
   end
@@ -48,14 +48,14 @@ describe LogicalQueryParser do
       it 'before parenthesis (1)' do
         result = parser.parse("#{ope}(aa OR bb)").to_sql(options)
         debug(result)
-        expect(result).to match sequence %w|NOT ( title aa OR body aa OR title bb OR body bb )|
+        expect(result).to match sequence %w|NOT ( ( title aa OR body aa ) OR ( title bb OR body bb ) )|
         expect(Doc.where(result).to_a).not_to be_nil
       end
 
       it 'before parenthesis (2)' do
         result = parser.parse("(aa OR bb) AND #{ope}(cc OR dd)").to_sql(options)
         debug(result)
-        expect(result).to match sequence %w|( title aa OR body aa OR title bb OR body bb ) AND NOT ( title cc OR body cc OR title dd OR body dd )|
+        expect(result).to match sequence %w|( ( title aa OR body aa ) OR ( title bb OR body bb ) ) AND NOT ( ( title cc OR body cc ) OR ( title dd OR body dd ) )|
         expect(Doc.where(result).to_a).not_to be_nil
       end
     end
@@ -85,28 +85,28 @@ describe LogicalQueryParser do
     it 'parses (1)' do
       result = parser.parse("(aa OR bb) AND cc").to_sql(options)
       debug(result)
-      expect(result).to match sequence %W|( title aa OR body aa ) OR ( title bb OR body bb ) AND ( title cc OR body cc )|
+      expect(result).to match sequence %W|( ( title aa OR body aa ) OR ( title bb OR body bb ) ) AND ( title cc OR body cc )|
       expect(Doc.where(result).to_a).not_to be_nil
     end
 
     it 'parses (2)' do
       result = parser.parse("aa AND (bb OR cc)").to_sql(options)
       debug(result)
-      expect(result).to match sequence %W|( title aa OR body aa ) AND ( title bb OR body bb ) OR ( title cc OR body cc )|
+      expect(result).to match sequence %W|( title aa OR body aa ) AND ( ( title bb OR body bb ) OR ( title cc OR body cc ) )|
       expect(Doc.where(result).to_a).not_to be_nil
     end
 
     it 'parses (3)' do
       result = parser.parse("(aa OR bb) AND (cc OR dd)").to_sql(options)
       debug(result)
-      expect(result).to match sequence %W|( title aa OR body aa ) OR ( title bb OR body bb ) AND ( title cc OR body cc ) OR ( title dd OR body dd )|
+      expect(result).to match sequence %W|( ( title aa OR body aa ) OR ( title bb OR body bb ) ) AND ( ( title cc OR body cc ) OR ( title dd OR body dd ) )|
       expect(Doc.where(result).to_a).not_to be_nil
     end
 
     it 'parses (4)' do
       result = parser.parse('"aa bb" AND NOT "cc dd" AND (ee OR ff)').to_sql(options)
       debug(result)
-      expect(result).to match sequence %W|( title aa bb OR body aa bb ) AND ( title NOT cc dd AND body NOT cc dd ) AND ( ( title ee OR body ee ) OR ( title ff OR body ff ) )|
+      expect(result).to match sequence %W|( title aa\ bb OR body aa\ bb ) AND ( title NOT cc\ dd AND body NOT cc\ dd ) AND ( ( title ee OR body ee ) OR ( title ff OR body ff ) )|
       expect(Doc.where(result).to_a).not_to be_nil
     end
   end
@@ -166,14 +166,14 @@ describe LogicalQueryParser do
     it 'searches nested association' do
       relations = LogicalQueryParser.search("aa AND bb", Doc, :title, tags: [:name, users: :name])
       debug(relations.to_sql)
-      expect(relations.to_sql).to match sequence %W|( ( title aa OR tags name aa OR users name aa ) AND ( title bb OR tags name bb OR users name bb )|
+      expect(relations.to_sql).to match sequence %W|( ( ( title aa OR tags name aa ) OR users name aa ) AND ( ( title bb OR tags name bb ) OR users name bb )|
       expect(relations.to_a).not_to be_nil
     end
 
     it 'searches nested association with array' do
       relations = LogicalQueryParser.search("aa AND bb", Doc, [:title, tags: [:name, users: :name]])
       debug(relations.to_sql)
-      expect(relations.to_sql).to match sequence %W|( ( title aa OR tags name aa OR users name aa ) AND ( title bb OR tags name bb OR users name bb )|
+      expect(relations.to_sql).to match sequence %W|( ( ( title aa OR tags name aa ) OR users name aa ) AND ( ( title bb OR tags name bb ) OR users name bb )|
       expect(relations.to_a).not_to be_nil
     end
   end

--- a/spec/logical_query_parser/nodes/active_record_spec.rb
+++ b/spec/logical_query_parser/nodes/active_record_spec.rb
@@ -172,6 +172,12 @@ describe LogicalQueryParser do
     end
 
     it 'returns nil (2)' do
+      result = parser.parse("OR")
+      debug(result)
+      expect(result).to be_nil
+    end
+
+    it 'returns nil (3)' do
       result = parser.parse("NOT AND")
       debug(result)
       expect(result).to be_nil

--- a/spec/logical_query_parser/nodes/active_record_spec.rb
+++ b/spec/logical_query_parser/nodes/active_record_spec.rb
@@ -27,6 +27,36 @@ describe LogicalQueryParser do
       expect(result).to match sequence %w|title aa\ bb OR body aa\ bb|
       expect(Doc.where(result).to_a).not_to be_nil
     end
+
+    ['and', 'or', 'not'].each do |ope|
+      it "parses word ending with #{ope}" do
+        result = parser.parse("xx#{ope}").to_sql(options)
+        debug(result)
+        expect(result).to match sequence %W|title xx#{ope} OR body xx#{ope}|
+        expect(Doc.where(result).to_a).not_to be_nil
+      end
+
+      it "parses word starting with #{ope}" do
+        result = parser.parse("#{ope}xx").to_sql(options)
+        debug(result)
+        expect(result).to match sequence %W|title #{ope}xx OR body #{ope}xx|
+        expect(Doc.where(result).to_a).not_to be_nil
+      end
+
+      it "parses word with #{ope} in the middle" do
+        result = parser.parse("xx#{ope}yy").to_sql(options)
+        debug(result)
+        expect(result).to match sequence %W|title xx#{ope}yy OR body xx#{ope}yy|
+        expect(Doc.where(result).to_a).not_to be_nil
+      end
+    end
+
+    it "parses word with - in the middle" do
+      result = parser.parse("xx-yy").to_sql(options)
+      debug(result)
+      expect(result).to match sequence %W|title xx-yy OR body xx-yy|
+      expect(Doc.where(result).to_a).not_to be_nil
+    end
   end
 
   ['NOT ', '- ', '-'].each do |ope|


### PR DESCRIPTION
Fixes #6 

I tried few ways, but they accepted 'AND' or 'aa AND', so they only way I found was using !{ } to use ruby to reject words which are logical operators, because changing unquoted word to [\S]+ worked to fix parsing those words but broke parsing logic operators.

Also, I changed the tests, as they could pass although sql was broken. For example, trying to fix the issue, I broke logic expressions, and 'aa AND bb' generated `("docs"."title" LIKE '%aa%' OR "docs"."body" LIKE '%aa%') AND ("docs"."title" LIKE '%AND%' OR "docs"."body" LIKE '%AND%') AND ("docs"."title" LIKE '%bb%' OR "docs"."body" LIKE '%bb%')`, but the test passed.

If you know a better way to fix the grammar, I think the first 2 commits would still be good.