### PR TITLE
support using a different grammar with LogicalQueryParser.search

### DIFF
--- a/lib/logical_query_parser.rb
+++ b/lib/logical_query_parser.rb
@@ -14,10 +14,11 @@ module LogicalQueryParser
       LogicalQueryParserParser.new
     end
 
-    def search(query, relations, *options)
+    def search(query, relations, *args, parser: new, **options)
       relations = relations.all if relations.respond_to?(:all)
-      assoc = resolve_assocs(relations.klass, *options)
-      sql = new.parse(query).to_sql(model: relations.klass, columns: assoc.column_mapping)
+      args << options if options.any?
+      assoc = resolve_assocs(relations.klass, *args)
+      sql = parser.parse(query).to_sql(model: relations.klass, columns: assoc.column_mapping)
       relations.joins(assoc.structure).where(sql)
     end
 

--- a/spec/logical_query_parser/nodes/active_record_spec.rb
+++ b/spec/logical_query_parser/nodes/active_record_spec.rb
@@ -213,4 +213,34 @@ describe LogicalQueryParser do
       expect(relations.to_a).not_to be_nil
     end
   end
+
+  context 'search with parser' do
+    it 'searches' do
+      relations = LogicalQueryParser.search("aa AND bb", Doc, :title, :body, parser: LogicalQueryParserParser.new)
+      debug(relations.to_sql)
+      expect(relations.to_sql).to match sequence %W|( ( title aa OR body aa ) AND ( title bb OR body bb )|
+      expect(relations.to_a).not_to be_nil
+    end
+
+    it 'searches one association' do
+      relations = LogicalQueryParser.search("aa AND bb", Doc, :title, { tags: :name }, parser: LogicalQueryParserParser.new)
+      debug(relations.to_sql)
+      expect(relations.to_sql).to match sequence %W|( ( title aa OR tags name aa ) AND ( title bb OR tags name bb )|
+      expect(relations.to_a).not_to be_nil
+    end
+
+    it 'searches nested association' do
+      relations = LogicalQueryParser.search("aa AND bb", Doc, :title, tags: [:name, users: :name], parser: LogicalQueryParserParser.new)
+      debug(relations.to_sql)
+      expect(relations.to_sql).to match sequence %W|( ( ( title aa OR tags name aa ) OR users name aa ) AND ( ( title bb OR tags name bb ) OR users name bb )|
+      expect(relations.to_a).not_to be_nil
+    end
+
+    it 'searches nested association with array' do
+      relations = LogicalQueryParser.search("aa AND bb", Doc, [:title, tags: [:name, users: :name]], parser: LogicalQueryParserParser.new)
+      debug(relations.to_sql)
+      expect(relations.to_sql).to match sequence %W|( ( ( title aa OR tags name aa ) OR users name aa ) AND ( ( title bb OR tags name bb ) OR users name bb )|
+      expect(relations.to_a).not_to be_nil
+    end
+  end
 end


### PR DESCRIPTION
There are cases where I want to use a simpler grammar, for example one which only supports words and quoted words, and use AND to find results with all tokens, or another grammar which uses OR to find results with any token.

With this option, I was able to do it writting a grammar (treetop file and modules with to_sql methods), but still use the search method and the association resolver.